### PR TITLE
Switch to FindFirstObjectByType for runtime lookups

### DIFF
--- a/Scripts/Boid.cs
+++ b/Scripts/Boid.cs
@@ -58,7 +58,7 @@ public class Boid : MonoBehaviour
     void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
-        mgr = FindObjectOfType<BoidManager>();
+        mgr = FindFirstObjectByType<BoidManager>();
         spikeMask = LayerMask.GetMask("Spike");           // ★ Layer 需命名 Spike
         UpdateTierVisual();
     }
@@ -76,7 +76,8 @@ public class Boid : MonoBehaviour
             + spikeRepelWeight * SteerAvoidSpike()        // ★ 新增
             + wallRepelWeight * SteerAvoidWalls();
 
-        Vector2 v = rb.linearVelocity + accel * Time.fixedDeltaTime;
+        float dt = Time.fixedDeltaTime;
+        Vector2 v = rb.linearVelocity + accel * dt;
         rb.linearVelocity = Vector2.ClampMagnitude(v, maxSpeed);
 
         if (rb.linearVelocity.sqrMagnitude > 0.0001f)
@@ -101,27 +102,51 @@ public class Boid : MonoBehaviour
     {
         if (neighbors.Count == 0) return Vector2.zero;
         Vector2 sum = Vector2.zero;
+        float radiusSqr = separationRadius * separationRadius;
+        int validCount = 0;
         foreach (var n in neighbors)
         {
+            if (!n) continue;
             Vector2 diff = (Vector2)transform.position - (Vector2)n.transform.position;
-            float d = diff.magnitude;
-            if (d < separationRadius && d > 0f) sum += diff / d;
+            float sqrMag = diff.sqrMagnitude;
+            if (sqrMag < radiusSqr && sqrMag > 1e-6f)
+            {
+                float invMag = 1f / Mathf.Sqrt(sqrMag);
+                sum += diff * invMag;
+                validCount++;
+            }
         }
-        return SteerTowards(sum / neighbors.Count);
+        return validCount > 0 ? SteerTowards(sum / validCount) : Vector2.zero;
     }
     Vector2 SteerCohesion()
     {
         if (neighbors.Count == 0) return Vector2.zero;
         Vector2 center = Vector2.zero;
-        foreach (var n in neighbors) center += (Vector2)n.transform.position;
-        return SteerTowards(center / neighbors.Count - rb.position);
+        int validCount = 0;
+        foreach (var n in neighbors)
+        {
+            if (!n) continue;
+            center += (Vector2)n.transform.position;
+            validCount++;
+        }
+        if (validCount == 0) return Vector2.zero;
+        float invCount = 1f / validCount;
+        return SteerTowards(center * invCount - rb.position);
     }
     Vector2 SteerAlignment()
     {
         if (neighbors.Count == 0) return Vector2.zero;
         Vector2 avg = Vector2.zero;
-        foreach (var n in neighbors) avg += n.rb.linearVelocity;
-        return SteerTowards(avg / neighbors.Count);
+        int validCount = 0;
+        foreach (var n in neighbors)
+        {
+            if (!n) continue;
+            avg += n.rb.linearVelocity;
+            validCount++;
+        }
+        if (validCount == 0) return Vector2.zero;
+        float invCount = 1f / validCount;
+        return SteerTowards(avg * invCount);
     }
     Vector2 SteerFleePredator()
     {
@@ -136,17 +161,38 @@ public class Boid : MonoBehaviour
         Collider2D hit = Physics2D.OverlapCircle(transform.position, spikeRepelRadius, spikeMask);
         if (!hit) return Vector2.zero;
 
-        Vector2 away = (Vector2)transform.position - hit.attachedRigidbody.position;
+        Vector2 spikePos = hit.attachedRigidbody ? hit.attachedRigidbody.position : (Vector2)hit.transform.position;
+        Vector2 away = (Vector2)transform.position - spikePos;
         return SteerTowards(away);
     }
     Vector2 SteerAvoidWalls()
     {
         Vector2 steer = Vector2.zero, pos = rb.position, half = mgr.spawnArea;
         float r = wallRepelRadius;
-        float dL = pos.x + half.x; if (dL < r) steer += Vector2.right * Mathf.Pow(1f - dL / r, 2);
-        float dR = half.x - pos.x; if (dR < r) steer += Vector2.left * Mathf.Pow(1f - dR / r, 2);
-        float dB = pos.y + half.y; if (dB < r) steer += Vector2.up * Mathf.Pow(1f - dB / r, 2);
-        float dT = half.y - pos.y; if (dT < r) steer += Vector2.down * Mathf.Pow(1f - dT / r, 2);
+        float dL = pos.x + half.x;
+        if (dL < r)
+        {
+            float ratio = 1f - dL / r;
+            steer += Vector2.right * (ratio * ratio);
+        }
+        float dR = half.x - pos.x;
+        if (dR < r)
+        {
+            float ratio = 1f - dR / r;
+            steer += Vector2.left * (ratio * ratio);
+        }
+        float dB = pos.y + half.y;
+        if (dB < r)
+        {
+            float ratio = 1f - dB / r;
+            steer += Vector2.up * (ratio * ratio);
+        }
+        float dT = half.y - pos.y;
+        if (dT < r)
+        {
+            float ratio = 1f - dT / r;
+            steer += Vector2.down * (ratio * ratio);
+        }
         return SteerTowards(steer);
     }
     Vector2 SteerTowards(Vector2 vec)
@@ -161,10 +207,14 @@ public class Boid : MonoBehaviour
     void SampleNeighbors()
     {
         neighbors.Clear();
+        float radiusSqr = perceptionRadius * perceptionRadius;
         foreach (var o in mgr.ActiveBoids)
-            if (o != this &&
-                ((Vector2)o.transform.position - rb.position).magnitude < perceptionRadius)
+        {
+            if (!o || o == this) continue;
+            Vector2 delta = (Vector2)o.transform.position - rb.position;
+            if (delta.sqrMagnitude < radiusSqr)
                 neighbors.Add(o);
+        }
     }
     void BounceWalls()
     {

--- a/Scripts/Menu/MenuBackground.cs
+++ b/Scripts/Menu/MenuBackground.cs
@@ -43,7 +43,7 @@ public class MenuBackground : MonoBehaviour
     #if UNITY_2023_1_OR_NEWER
         realPlayer = FindFirstObjectByType<PlayerController>(FindObjectsInactive.Include);
     #else
-        realPlayer = FindObjectOfType<PlayerController>();
+        realPlayer = FindFirstObjectByType<PlayerController>();
     #endif
         if (realPlayer)
         {

--- a/Scripts/Shop/Mods/0923/CritToSmallsPerWave.cs
+++ b/Scripts/Shop/Mods/0923/CritToSmallsPerWave.cs
@@ -12,7 +12,7 @@ public class CritToSmallsPerWave : PlayerModifier
     public override void Apply(PlayerController player)
     {
         sStacks++;
-        if (!sRunner) sRunner = player ? player : Object.FindObjectOfType<PlayerController>();
+        if (!sRunner) sRunner = player ? player : Object.FindFirstObjectByType<PlayerController>();
         if (sCo == null && sRunner) sCo = sRunner.StartCoroutine(Loop());
         Recalc(); // 立即生效
     }

--- a/Scripts/Shop/Mods/0926/CritPerSpikeWall.cs
+++ b/Scripts/Shop/Mods/0926/CritPerSpikeWall.cs
@@ -13,7 +13,7 @@ public class CritPerSpikeWall : PlayerModifier
     public override void Apply(PlayerController player)
     {
         sStacks++;
-        if (!sRunner) sRunner = player ? player : Object.FindObjectOfType<PlayerController>();
+        if (!sRunner) sRunner = player ? player : Object.FindFirstObjectByType<PlayerController>();
         if (sCo == null && sRunner) sCo = sRunner.StartCoroutine(Loop());
     }
 

--- a/Scripts/Shop/Mods/0926/SpikeWallsMinusOne.cs
+++ b/Scripts/Shop/Mods/0926/SpikeWallsMinusOne.cs
@@ -7,14 +7,14 @@ public class SpikeWallsMinusOne : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var sm = Object.FindObjectOfType<SpikeManager>();
+        var sm = Object.FindFirstObjectByType<SpikeManager>();
         if (!sm) return;
         if (sm.spikesPerRound > 1) { sm.spikesPerRound -= 1; sApplied += 1; }
     }
 
     public static void HardReset()
     {
-        var sm = Object.FindObjectOfType<SpikeManager>();
+        var sm = Object.FindFirstObjectByType<SpikeManager>();
         if (sm && sApplied > 0) sm.spikesPerRound = Mathf.Max(1, sm.spikesPerRound + sApplied);
         sApplied = 0;
     }

--- a/Scripts/Shop/Mods/0926/SpikeWallsPlusOneSpeed.cs
+++ b/Scripts/Shop/Mods/0926/SpikeWallsPlusOneSpeed.cs
@@ -9,20 +9,20 @@ public class SpikeWallsPlusOneSpeed : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var sm = Object.FindObjectOfType<SpikeManager>();
+        var sm = Object.FindFirstObjectByType<SpikeManager>();
         if (sm) { sm.spikesPerRound += 1; sSpikeApplied += 1; }
 
-        var pc = player ? player : Object.FindObjectOfType<PlayerController>();
+        var pc = player ? player : Object.FindFirstObjectByType<PlayerController>();
         if (pc) { pc.maxSpeed *= SpeedMul; sSpeedStacks += 1; }
     }
 
     public static void HardReset()
     {
-        var sm = Object.FindObjectOfType<SpikeManager>();
+        var sm = Object.FindFirstObjectByType<SpikeManager>();
         if (sm && sSpikeApplied > 0) sm.spikesPerRound = Mathf.Max(1, sm.spikesPerRound - sSpikeApplied);
         sSpikeApplied = 0;
 
-        var pc = Object.FindObjectOfType<PlayerController>();
+        var pc = Object.FindFirstObjectByType<PlayerController>();
         if (pc && sSpeedStacks > 0) pc.maxSpeed /= Mathf.Pow(SpeedMul, sSpeedStacks);
         sSpeedStacks = 0;
     }

--- a/Scripts/Shop/Mods/before/AddGoldChanceFlat.cs
+++ b/Scripts/Shop/Mods/before/AddGoldChanceFlat.cs
@@ -7,7 +7,7 @@ public class AddGoldChanceFlat : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr) return;
         mgr.goldenChance = Mathf.Clamp01(mgr.goldenChance + add);
     }

--- a/Scripts/Shop/Mods/before/AddGoldChanceFlat1.cs
+++ b/Scripts/Shop/Mods/before/AddGoldChanceFlat1.cs
@@ -7,7 +7,7 @@ public class AddGoldChanceFlat1 : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr) return;
         mgr.goldenChance = Mathf.Clamp01(mgr.goldenChance + add);
     }

--- a/Scripts/Shop/Mods/before/BoidSpeedDownForceUp.cs
+++ b/Scripts/Shop/Mods/before/BoidSpeedDownForceUp.cs
@@ -8,7 +8,7 @@ public class BoidSpeedDownForceUp : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
         if (!bm) return;
 
         // 影响未来生成

--- a/Scripts/Shop/Mods/before/BoidSpeedUPForceDown.cs
+++ b/Scripts/Shop/Mods/before/BoidSpeedUPForceDown.cs
@@ -8,7 +8,7 @@ public class BoidSpeedUpForceDown : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
         if (!bm) return;
 
         // 影响未来生成

--- a/Scripts/Shop/Mods/before/DoubleNaturalGoldChance.cs
+++ b/Scripts/Shop/Mods/before/DoubleNaturalGoldChance.cs
@@ -7,7 +7,7 @@ public class DoubleNaturalGoldChance : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr) return;
 
         // 对“当前概率”直接乘算；仅物理上限到 100%

--- a/Scripts/Shop/Mods/before/EatNearestOnGold.cs
+++ b/Scripts/Shop/Mods/before/EatNearestOnGold.cs
@@ -20,7 +20,7 @@ public class EatNearestOnGold : PlayerModifier
     static void OnGold(Vector2 _)
     {
         var bm = BoidManager.Instance; if (bm == null) return;
-        var pc = Object.FindObjectOfType<PlayerController>(); if (!pc) return;
+        var pc = Object.FindFirstObjectByType<PlayerController>(); if (!pc) return;
 
         int need = sStacks * sExtraPerStack;
         if (need <= 0 || bm.ActiveBoids == null || bm.ActiveBoids.Count == 0) return;

--- a/Scripts/Shop/Mods/before/ExtraGoldPerWave.cs
+++ b/Scripts/Shop/Mods/before/ExtraGoldPerWave.cs
@@ -5,7 +5,7 @@ public class ExtraGoldPerWave : PlayerModifier
 {
     public override void Apply(PlayerController player)
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
         if (bm) bm.extraGoldenPerWave += 1;     // 需要在 BoidManager 里新增该字段，见下文补丁
     }
 }

--- a/Scripts/Shop/Mods/before/GoldBuffSpeedFor2s.cs
+++ b/Scripts/Shop/Mods/before/GoldBuffSpeedFor2s.cs
@@ -34,7 +34,7 @@ public class GoldBuffSpeedFor2s : PlayerModifier
 
     static void OnGoldFish(Vector2 _)
     {
-        if (!sPlayer) sPlayer = Object.FindObjectOfType<PlayerController>();
+        if (!sPlayer) sPlayer = Object.FindFirstObjectByType<PlayerController>();
         if (!sPlayer || sOwned <= 0) return;
 
         float targetMult = Mathf.Pow(sPerItem, sOwned); // 例：买2个→1.1^2=1.21

--- a/Scripts/Shop/Mods/before/GoldChanceFromSpeed.cs
+++ b/Scripts/Shop/Mods/before/GoldChanceFromSpeed.cs
@@ -17,7 +17,7 @@ public class GoldChanceFromSpeed : PlayerModifier
     public override void Apply(PlayerController player)
     {
         sStacks++;
-        if (!sPlayer) sPlayer = player ? player : Object.FindObjectOfType<PlayerController>();
+        if (!sPlayer) sPlayer = player ? player : Object.FindFirstObjectByType<PlayerController>();
         if (!sHooked && sPlayer) { sCo = sPlayer.StartCoroutine(Loop()); sHooked = true; }
     }
 

--- a/Scripts/Shop/Mods/before/IncomeIfUnderFishCap.cs
+++ b/Scripts/Shop/Mods/before/IncomeIfUnderFishCap.cs
@@ -14,7 +14,7 @@ public class IncomeIfUnderFishCap : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        sRunner = player ? player : Object.FindObjectOfType<PlayerController>();
+        sRunner = player ? player : Object.FindFirstObjectByType<PlayerController>();
         sThresh = threshold; sIncome = incomePerSec;
         if (!sHooked && sRunner){ sCo = sRunner.StartCoroutine(Loop()); sHooked = true; }
     }

--- a/Scripts/Shop/Mods/before/IncomePerSec1.cs
+++ b/Scripts/Shop/Mods/before/IncomePerSec1.cs
@@ -11,7 +11,7 @@ public class IncomePerSec1 : PlayerModifier
     public override void Apply(PlayerController player)
     {
         stacks = Mathf.Max(0, stacks + 1);
-        if (!holder) holder = Object.FindObjectOfType<PlayerController>();
+        if (!holder) holder = Object.FindFirstObjectByType<PlayerController>();
         if (co == null && holder) co = holder.StartCoroutine(Loop());
     }
 

--- a/Scripts/Shop/Mods/before/IncomePerSec2.cs
+++ b/Scripts/Shop/Mods/before/IncomePerSec2.cs
@@ -11,7 +11,7 @@ public class IncomePerSec2 : PlayerModifier
     public override void Apply(PlayerController player)
     {
         stacks = Mathf.Max(0, stacks + 3);
-        if (!holder) holder = Object.FindObjectOfType<PlayerController>();
+        if (!holder) holder = Object.FindFirstObjectByType<PlayerController>();
         if (co == null && holder) co = holder.StartCoroutine(Loop());
     }
 

--- a/Scripts/Shop/Mods/before/InterestEvery5s.cs
+++ b/Scripts/Shop/Mods/before/InterestEvery5s.cs
@@ -16,7 +16,7 @@ public class InterestEvery5s : PlayerModifier
     public override void Apply(PlayerController player)
     {
         sStacks++;
-        if (!sRunner) sRunner = Object.FindObjectOfType<PlayerController>();
+        if (!sRunner) sRunner = Object.FindFirstObjectByType<PlayerController>();
         if (sCo == null && sRunner) sCo = sRunner.StartCoroutine(Loop());
 
         if (!sHooked)

--- a/Scripts/Shop/Mods/before/OverTargetSpeedAccelBoost.cs
+++ b/Scripts/Shop/Mods/before/OverTargetSpeedAccelBoost.cs
@@ -14,7 +14,7 @@ public class OverTargetSpeedAccelBoost : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        sPlayer = player ? player : Object.FindObjectOfType<PlayerController>();
+        sPlayer = player ? player : Object.FindFirstObjectByType<PlayerController>();
         sMult = Mathf.Max(1f, multiplier);
         sInv  = 1f / sMult;
         if (!sHooked && sPlayer){ sCo = sPlayer.StartCoroutine(Loop()); sHooked = true; }

--- a/Scripts/Shop/Mods/before/PlusOnePerWave.cs
+++ b/Scripts/Shop/Mods/before/PlusOnePerWave.cs
@@ -7,7 +7,7 @@ public class PlusOnePerWave : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr) return;
         mgr.boidsPerWave += add;
     }

--- a/Scripts/Shop/Mods/before/PlusTwoPerWave.cs
+++ b/Scripts/Shop/Mods/before/PlusTwoPerWave.cs
@@ -7,7 +7,7 @@ public class PlusTwoPerWave : PlayerModifier
 
     public override void Apply(PlayerController player)
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr) return;
         mgr.boidsPerWave += add;
     }

--- a/Scripts/Shop/Mods/before/RampUpSmallsPerRound.cs
+++ b/Scripts/Shop/Mods/before/RampUpSmallsPerRound.cs
@@ -20,7 +20,7 @@ public class RampUpSmallsPerRound : PlayerModifier
 
     static void OnRoundBegin()
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
         if (!bm) return;
 
         // 撤销上一局的临时加成，然后计算本局

--- a/Scripts/Shop/Mods/before/ReduceSpikePenaltyTo10.cs
+++ b/Scripts/Shop/Mods/before/ReduceSpikePenaltyTo10.cs
@@ -9,7 +9,7 @@ public class ReduceSpikePenaltyTo10 : PlayerModifier
         if (gm) gm.spikePenaltyRate = 0.05f;   // 需要在 GameManager 里公开该字段，见下文补丁
 
         // 从本大局的商店池里移除自己（直到新一大局重置）
-        var sm = Object.FindObjectOfType<ShopManager>();
+        var sm = Object.FindFirstObjectByType<ShopManager>();
         if (!sm) return;
         // 在池里找到“指向本 Modifier 的 ItemConfig”并禁用
         foreach (var c in sm.pool)

--- a/Scripts/Shop/Mods/before/SmallToGoldChance.cs
+++ b/Scripts/Shop/Mods/before/SmallToGoldChance.cs
@@ -20,10 +20,10 @@ public class SmallToGoldChance : PlayerModifier
     {
         if (Random.value > chance) return;
 
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr || !mgr.boidPrefab) return;
 
-        var pTr = mgr.Player ? mgr.Player : Object.FindObjectOfType<PlayerController>()?.transform;
+        var pTr = mgr.Player ? mgr.Player : Object.FindFirstObjectByType<PlayerController>()?.transform;
         if (!pTr) return;
 
         Vector2 spawnPos;

--- a/Scripts/Shop/Mods/before/Spawn3SmallOnGold.cs
+++ b/Scripts/Shop/Mods/before/Spawn3SmallOnGold.cs
@@ -16,10 +16,10 @@ public class Spawn3SmallOnGold : PlayerModifier
 
     void Handle()
     {
-        var mgr = Object.FindObjectOfType<BoidManager>();
+        var mgr = Object.FindFirstObjectByType<BoidManager>();
         if (!mgr || !mgr.boidPrefab) return;
 
-        var pTr = mgr.Player ? mgr.Player : Object.FindObjectOfType<PlayerController>()?.transform;
+        var pTr = mgr.Player ? mgr.Player : Object.FindFirstObjectByType<PlayerController>()?.transform;
         if (!pTr) return;
 
         for (int i = 0; i < 1; i++)

--- a/Scripts/Shop/Mods/before/SpawnGoldOnGold.cs
+++ b/Scripts/Shop/Mods/before/SpawnGoldOnGold.cs
@@ -25,8 +25,8 @@ public class SpawnGoldOnGold : PlayerModifier
 
     static void OnGold(Vector2 _)
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
-        var pl = Object.FindObjectOfType<PlayerController>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
+        var pl = Object.FindFirstObjectByType<PlayerController>();
         if (!bm || !pl) return;
 
         float eff = 1f - Mathf.Pow(1f - sBaseChance, sStacks);

--- a/Scripts/Shop/Mods/before/SpawnSmallOnSmall.cs
+++ b/Scripts/Shop/Mods/before/SpawnSmallOnSmall.cs
@@ -25,8 +25,8 @@ public class SpawnSmallOnSmall : PlayerModifier
 
     static void OnSmall(Vector2 _)
     {
-        var bm = Object.FindObjectOfType<BoidManager>();
-        var pl = Object.FindObjectOfType<PlayerController>();
+        var bm = Object.FindFirstObjectByType<BoidManager>();
+        var pl = Object.FindFirstObjectByType<PlayerController>();
         if (!bm || !pl) return;
 
         float eff = 1f - Mathf.Pow(1f - sBaseChance, sStacks);

--- a/Scripts/Shop/ShopManager.cs
+++ b/Scripts/Shop/ShopManager.cs
@@ -153,7 +153,7 @@ public class ShopManager : MonoBehaviour
 
         if (slot.cfg.modifier)
         {
-            var player = FindObjectOfType<PlayerController>();
+            var player = FindFirstObjectByType<PlayerController>();
             slot.cfg.modifier.Apply(player);
         }
 

--- a/Scripts/World/Spike.cs
+++ b/Scripts/World/Spike.cs
@@ -26,7 +26,7 @@ public class Spike : MonoBehaviour
         // 小鱼：按配置处理
         if (other.TryGetComponent(out Boid b))
         {
-            var bm = FindObjectOfType<BoidManager>();
+            var bm = FindFirstObjectByType<BoidManager>();
             if (!bm) { Destroy(b.gameObject); return; }
 
             // 道具：刺杀算玩家捕食


### PR DESCRIPTION
## Summary
- replace all usages of the deprecated FindObjectOfType API with FindFirstObjectByType
- keep player, spike, boid, and shop modifiers using the updated lookup to preserve behaviour

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d7541c2b848325b09432f78b51247f