### PR TITLE
Add randomized boid multipliers and average them during fusion

### DIFF
--- a/Scripts/Boid.cs
+++ b/Scripts/Boid.cs
@@ -48,6 +48,21 @@ public class Boid : MonoBehaviour
     [HideInInspector] public bool isGolden = false;
     [HideInInspector] public int scoreValue = 1;
 
+    /* ---------- 随机/全局系数 ---------- */
+    float baseMaxSpeed;
+    float baseMaxForce;
+    Vector3 baseScale;
+
+    float randomSpeedScale = 1f;
+    float randomForceScale = 1f;
+    float randomSizeScale = 1f;
+
+    float globalSpeedScale = 1f;
+    float globalForceScale = 1f;
+
+    float goldenSpeedScale = 1f;
+    float goldenForceScale = 1f;
+
     /* ---------- 引用 ---------- */
     Rigidbody2D rb;
     BoidManager mgr;
@@ -60,6 +75,12 @@ public class Boid : MonoBehaviour
         rb = GetComponent<Rigidbody2D>();
         mgr = FindFirstObjectByType<BoidManager>();
         spikeMask = LayerMask.GetMask("Spike");           // ★ Layer 需命名 Spike
+
+        baseMaxSpeed = maxSpeed;
+        baseMaxForce = maxForce;
+        baseScale = transform.localScale;
+        UpdateScaledStats();
+
         UpdateTierVisual();
     }
 
@@ -90,8 +111,7 @@ public class Boid : MonoBehaviour
     public void ConfigureAsGolden(float speedMul, float forceMul, int val, Color col)
     {
         isGolden = true; scoreValue = val;
-        maxSpeed *= speedMul;
-        maxForce *= forceMul;
+        SetGoldenScales(speedMul, forceMul);
         GetComponent<SpriteRenderer>().color = col;
         GetComponent<Trail2D>()?.RefreshFromSprite();
     }
@@ -281,7 +301,49 @@ public class Boid : MonoBehaviour
             GlobalEvents.RaiseFishBoundaryBounce(this, pos);
         }
     }
-    
+
+    public void SetRandomScales(float speedScale, float forceScale, float sizeScale)
+    {
+        randomSpeedScale = speedScale;
+        randomForceScale = forceScale;
+        randomSizeScale = sizeScale;
+        UpdateScaledStats();
+    }
+
+    public void SetGlobalScales(float speedScale, float forceScale)
+    {
+        globalSpeedScale = speedScale;
+        globalForceScale = forceScale;
+        UpdateScaledStats();
+    }
+
+    public void MultiplyGlobalScales(float speedScale, float forceScale)
+    {
+        globalSpeedScale *= speedScale;
+        globalForceScale *= forceScale;
+        UpdateScaledStats();
+    }
+
+    public void SetGoldenScales(float speedScale, float forceScale)
+    {
+        goldenSpeedScale = speedScale;
+        goldenForceScale = forceScale;
+        UpdateScaledStats();
+    }
+
+    public float RandomSpeedScale => randomSpeedScale;
+    public float RandomForceScale => randomForceScale;
+    public float RandomSizeScale => randomSizeScale;
+    public float GlobalSpeedScale => globalSpeedScale;
+    public float GlobalForceScale => globalForceScale;
+
+    void UpdateScaledStats()
+    {
+        maxSpeed = baseMaxSpeed * randomSpeedScale * globalSpeedScale * goldenSpeedScale;
+        maxForce = baseMaxForce * randomForceScale * globalForceScale * goldenForceScale;
+        transform.localScale = baseScale * randomSizeScale;
+    }
+
     public void SetTier(int t)
     {
         fusionTier = Mathf.Clamp(t, 0, (BoidManager.Instance ? BoidManager.Instance.maxFusionTier : 2));

--- a/Scripts/BoidManager.cs
+++ b/Scripts/BoidManager.cs
@@ -152,9 +152,12 @@ public class BoidManager : MonoBehaviour
             Vector2 pos = (Vector2)sp.position + Random.insideUnitCircle * scatterRadius;
             Boid b = Instantiate(boidPrefab, pos, Quaternion.identity, transform);
 
-            /* 原先的 b.Initialise(this); 已不需要 */
-        b.maxSpeed *= globalSpeedMult;
-        b.maxForce *= globalForceMult;
+            float speedScale = Random.Range(0.99f, 1.02f);
+            float forceScale = Random.Range(0.99f, 1.02f);
+            float sizeScale  = Random.Range(0.99f, 1.02f);
+
+            b.SetRandomScales(speedScale, forceScale, sizeScale);
+            b.SetGlobalScales(globalSpeedMult, globalForceMult);
 
 
             // ① 若你已算好 goldenChanceAddFromSpeed（0~1）：
@@ -182,11 +185,13 @@ public class BoidManager : MonoBehaviour
             Vector2 pos = (Vector2)sp.position + Random.insideUnitCircle * scatterRadius;
 
             Boid b = Instantiate(boidPrefab, pos, Quaternion.identity, transform);
-            b.ConfigureAsGolden(goldenSpeedMultiplier, goldenForceMultiplier, goldenScoreValue, goldenColor);
+            float speedScale = Random.Range(0.99f, 1.02f);
+            float forceScale = Random.Range(0.99f, 1.02f);
+            float sizeScale  = Random.Range(0.99f, 1.02f);
 
-            // ★ 全局乘子同样作用于这批金鱼
-            b.maxSpeed *= globalSpeedMult;
-            b.maxForce *= globalForceMult;
+            b.SetRandomScales(speedScale, forceScale, sizeScale);
+            b.SetGlobalScales(globalSpeedMult, globalForceMult);
+            b.ConfigureAsGolden(goldenSpeedMultiplier, goldenForceMultiplier, goldenScoreValue, goldenColor);
 
 #if UNITY_2023_1_OR_NEWER
             b.GetComponent<Rigidbody2D>().linearVelocity = goldFleeDir * b.maxSpeed * 0.5f;
@@ -265,13 +270,19 @@ public class BoidManager : MonoBehaviour
 
        // 生成新鱼（同色，阶数+1），属性沿用原鱼
        Boid nb = Instantiate(boidPrefab, pos, Quaternion.identity, transform);
+
+        float avgSpeedScale = (a.RandomSpeedScale + b.RandomSpeedScale) * 0.5f;
+        float avgForceScale = (a.RandomForceScale + b.RandomForceScale) * 0.5f;
+        float avgSizeScale  = (a.RandomSizeScale  + b.RandomSizeScale)  * 0.5f;
+
+        nb.SetRandomScales(avgSpeedScale, avgForceScale, avgSizeScale);
+        nb.SetGlobalScales(globalSpeedMult, globalForceMult);
+
         if (a.isGolden)
             nb.ConfigureAsGolden(goldenSpeedMultiplier, goldenForceMultiplier, goldenScoreValue, goldenColor);
         else
             nb.isGolden = false;
 
-        nb.maxSpeed         = a.maxSpeed;
-        nb.maxForce         = a.maxForce;              // ← 用 maxForce 代替 accel
         nb.perceptionRadius = a.perceptionRadius;
         nb.separationRadius = a.separationRadius;
         nb.SetTier(a.fusionTier + 1);

--- a/Scripts/Menu/MenuBackground.cs
+++ b/Scripts/Menu/MenuBackground.cs
@@ -124,9 +124,12 @@ public class MenuBackground : MonoBehaviour
             Boid b = Instantiate(boidPrefab, pos, Quaternion.identity, bm.transform);
             b.isGolden = false;
 
-            // 全局乘子与初速度
-            b.maxSpeed *= bm.globalSpeedMult;
-            b.maxForce *= bm.globalForceMult;
+            float speedScale = Random.Range(0.99f, 1.02f);
+            float forceScale = Random.Range(0.99f, 1.02f);
+            float sizeScale  = Random.Range(0.99f, 1.02f);
+
+            b.SetRandomScales(speedScale, forceScale, sizeScale);
+            b.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
 
 #if UNITY_2023_1_OR_NEWER
             var rb = b.GetComponent<Rigidbody2D>();

--- a/Scripts/Shop/Mods/before/BoidSpeedDownForceUp.cs
+++ b/Scripts/Shop/Mods/before/BoidSpeedDownForceUp.cs
@@ -21,8 +21,7 @@ public class BoidSpeedDownForceUp : PlayerModifier
             foreach (var b in bm.ActiveBoids)
             {
                 if (!b) continue;
-                b.maxSpeed *= speedMul;
-                b.maxForce *= forceMul;
+                b.MultiplyGlobalScales(speedMul, forceMul);
             }
         }
     }

--- a/Scripts/Shop/Mods/before/BoidSpeedUPForceDown.cs
+++ b/Scripts/Shop/Mods/before/BoidSpeedUPForceDown.cs
@@ -21,8 +21,7 @@ public class BoidSpeedUpForceDown : PlayerModifier
             foreach (var b in bm.ActiveBoids)
             {
                 if (!b) continue;
-                b.maxSpeed *= speedMul;
-                b.maxForce *= forceMul;
+                b.MultiplyGlobalScales(speedMul, forceMul);
             }
         }
     }

--- a/Scripts/Shop/Mods/before/GoldBounceSplitGold.cs
+++ b/Scripts/Shop/Mods/before/GoldBounceSplitGold.cs
@@ -35,9 +35,13 @@ public class GoldBounceSplitGold : PlayerModifier
         Vector2 p2   = pos + back * sBack;
 
         var nb = Object.Instantiate(bm.boidPrefab, p2, Quaternion.identity, bm.transform);
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        nb.SetRandomScales(speedScale, forceScale, sizeScale);
+        nb.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         nb.ConfigureAsGolden(bm.goldenSpeedMultiplier, bm.goldenForceMultiplier, bm.goldenScoreValue, bm.goldenColor);
-        nb.maxSpeed *= bm.globalSpeedMult;
-        nb.maxForce *= bm.globalForceMult;
         nb.SetTier(b.fusionTier);
 #if UNITY_2023_1_OR_NEWER
         nb.GetComponent<Rigidbody2D>().linearVelocity = back * (nb.maxSpeed * sK);

--- a/Scripts/Shop/Mods/before/GoldBounceSplitSmall.cs
+++ b/Scripts/Shop/Mods/before/GoldBounceSplitSmall.cs
@@ -38,8 +38,13 @@ public class GoldBounceSplitSmall : PlayerModifier
 
         var nb = Object.Instantiate(bm.boidPrefab, p2, Quaternion.identity, bm.transform);
         nb.isGolden = false;
-        nb.maxSpeed *= bm.globalSpeedMult;
-        nb.maxForce *= bm.globalForceMult;
+
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        nb.SetRandomScales(speedScale, forceScale, sizeScale);
+        nb.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         nb.SetTier(b.fusionTier);
 #if UNITY_2023_1_OR_NEWER
         nb.GetComponent<Rigidbody2D>().linearVelocity = back * (nb.maxSpeed * sK);

--- a/Scripts/Shop/Mods/before/GoldSplitOnSmallBounce.cs
+++ b/Scripts/Shop/Mods/before/GoldSplitOnSmallBounce.cs
@@ -35,9 +35,13 @@ public class GoldSplitOnSmallBounce : PlayerModifier
         Vector2 p2 = pos + back * sBack;
 
         var nb = Object.Instantiate(bm.boidPrefab, p2, Quaternion.identity, bm.transform);
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        nb.SetRandomScales(speedScale, forceScale, sizeScale);
+        nb.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         nb.ConfigureAsGolden(bm.goldenSpeedMultiplier, bm.goldenForceMultiplier, bm.goldenScoreValue, bm.goldenColor);
-        nb.maxSpeed *= bm.globalSpeedMult;
-        nb.maxForce *= bm.globalForceMult;
         nb.SetTier(b.fusionTier);
 #if UNITY_2023_1_OR_NEWER
         nb.GetComponent<Rigidbody2D>().linearVelocity = back * (nb.maxSpeed * sK);

--- a/Scripts/Shop/Mods/before/SmallBounceSplitSmall.cs
+++ b/Scripts/Shop/Mods/before/SmallBounceSplitSmall.cs
@@ -36,8 +36,13 @@ public class SmallBounceSplitSmall : PlayerModifier
 
         var nb = Object.Instantiate(bm.boidPrefab, p2, Quaternion.identity, bm.transform);
         nb.isGolden = false;
-        nb.maxSpeed *= bm.globalSpeedMult;
-        nb.maxForce *= bm.globalForceMult;
+
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        nb.SetRandomScales(speedScale, forceScale, sizeScale);
+        nb.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         nb.SetTier(b.fusionTier);
 #if UNITY_2023_1_OR_NEWER
         nb.GetComponent<Rigidbody2D>().linearVelocity = back * (nb.maxSpeed * sK);

--- a/Scripts/Shop/Mods/before/SmallToGoldChance.cs
+++ b/Scripts/Shop/Mods/before/SmallToGoldChance.cs
@@ -31,6 +31,12 @@ public class SmallToGoldChance : PlayerModifier
         GetBehind(mgr, pTr, out spawnPos, out fleeDir);
 
         Boid b = Object.Instantiate(mgr.boidPrefab, spawnPos, Quaternion.identity, mgr.transform);
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        b.SetRandomScales(speedScale, forceScale, sizeScale);
+        b.SetGlobalScales(mgr.globalSpeedMult, mgr.globalForceMult);
         b.ConfigureAsGolden(mgr.goldenSpeedMultiplier, mgr.goldenForceMultiplier,
                             mgr.goldenScoreValue, mgr.goldenColor);
 #if UNITY_2023_1_OR_NEWER

--- a/Scripts/Shop/Mods/before/Spawn3SmallOnGold.cs
+++ b/Scripts/Shop/Mods/before/Spawn3SmallOnGold.cs
@@ -29,6 +29,12 @@ public class Spawn3SmallOnGold : PlayerModifier
             GetBehind(mgr, pTr, out spawnPos, out fleeDir);
 
             Boid b = Object.Instantiate(mgr.boidPrefab, spawnPos, Quaternion.identity, mgr.transform);
+            float speedScale = Random.Range(0.99f, 1.02f);
+            float forceScale = Random.Range(0.99f, 1.02f);
+            float sizeScale  = Random.Range(0.99f, 1.02f);
+
+            b.SetRandomScales(speedScale, forceScale, sizeScale);
+            b.SetGlobalScales(mgr.globalSpeedMult, mgr.globalForceMult);
 #if UNITY_2023_1_OR_NEWER
             b.GetComponent<Rigidbody2D>().linearVelocity = fleeDir * b.maxSpeed * initialSpeedFrac;
 #else

--- a/Scripts/Shop/Mods/before/SpawnGoldOnGold.cs
+++ b/Scripts/Shop/Mods/before/SpawnGoldOnGold.cs
@@ -41,11 +41,14 @@ public class SpawnGoldOnGold : PlayerModifier
         Vector2 pos = (Vector2)pl.transform.position - fwd * sBackOffset + Random.insideUnitCircle * 0.05f;
 
         Boid b = Object.Instantiate(bm.boidPrefab, pos, Quaternion.identity, bm.transform);
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        b.SetRandomScales(speedScale, forceScale, sizeScale);
+        b.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         if (golden)
             b.ConfigureAsGolden(bm.goldenSpeedMultiplier, bm.goldenForceMultiplier, bm.goldenScoreValue, bm.goldenColor);
-
-        b.maxSpeed *= bm.globalSpeedMult;
-        b.maxForce *= bm.globalForceMult;
 
 #if UNITY_2023_1_OR_NEWER
         var prv = pl.GetComponent<Rigidbody2D>().linearVelocity;

--- a/Scripts/Shop/Mods/before/SpawnSmallOnSmall.cs
+++ b/Scripts/Shop/Mods/before/SpawnSmallOnSmall.cs
@@ -41,13 +41,16 @@ public class SpawnSmallOnSmall : PlayerModifier
         Vector2 pos = (Vector2)pl.transform.position - fwd * sBackOffset + Random.insideUnitCircle * 0.05f;
 
         Boid b = Object.Instantiate(bm.boidPrefab, pos, Quaternion.identity, bm.transform);
+        float speedScale = Random.Range(0.99f, 1.02f);
+        float forceScale = Random.Range(0.99f, 1.02f);
+        float sizeScale  = Random.Range(0.99f, 1.02f);
+
+        b.SetRandomScales(speedScale, forceScale, sizeScale);
+        b.SetGlobalScales(bm.globalSpeedMult, bm.globalForceMult);
         if (golden)
             b.ConfigureAsGolden(bm.goldenSpeedMultiplier, bm.goldenForceMultiplier, bm.goldenScoreValue, bm.goldenColor);
         else
             b.isGolden = false;
-
-        b.maxSpeed *= bm.globalSpeedMult;
-        b.maxForce *= bm.globalForceMult;
 
 #if UNITY_2023_1_OR_NEWER
         var prv = pl.GetComponent<Rigidbody2D>().linearVelocity;


### PR DESCRIPTION
## Summary
- add persistent per-boid multipliers for speed, force, and size and apply them during every spawn path
- ensure fusion averages the contributing multipliers so merged boids inherit combined stats
- update modifiers and helpers to respect the new multiplier pipeline and keep global adjustments consistent

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d937c74dd88325b29a24f8f2e352cb