### PR TITLE
Fix score carryover when starting a new game

### DIFF
--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -263,10 +263,11 @@ public class GameManager : MonoBehaviour
     public void OnPlay()
     {
         NewRunReset();
+        currency = 0; totalEarned = 0; targetScore = firstTarget;
         EnterPlay();
         hasSuspended = false;    // 新开局不算“挂起”
         ResetRunUpgrades();
-        // —— 道具与商店 —— 
+        // —— 道具与商店 ——
         ShopManager.ResetPriceScaling();
         ShopManager.ResetRunBans();
         ShopManager.ResetRerollCost();
@@ -301,7 +302,6 @@ public class GameManager : MonoBehaviour
 
 
         if (bm) { bm.globalSpeedMult = 1f; bm.globalForceMult = 1f; }
-        currency = 0; totalEarned = 0; targetScore = firstTarget;
     }
     public void OnMainMenuContinue()
     {


### PR DESCRIPTION
## Summary
- reset the current score, total earned, and target before entering gameplay when starting a new run
- ensure the round checkpoint created for Continue reflects the fresh run values instead of the previous session

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dddd53fe488325b740274f0e6f4ea2