### PR TITLE
Add new modifiers for speed, crit overflow, and golden waves

### DIFF
--- a/Scripts/BoidManager.cs
+++ b/Scripts/BoidManager.cs
@@ -74,6 +74,9 @@ public class BoidManager : MonoBehaviour
     [Header("Golden Chance (runtime adds)")]
     [Range(0f,1f)] public float goldenChanceAddFromSpeed = 0f;   // 由道具①动态写入
 
+    [Header("Golden Wave Bonus")]
+    [Range(0f,1f)] public float fullGoldenWaveChance = 0f;
+
 
     void Awake()
     {
@@ -416,6 +419,12 @@ public class BoidManager : MonoBehaviour
         Vector2 flee = player ? ((Vector2)sp.position - (Vector2)player.position).normalized
                               : Vector2.up;
 
+        bool spawnFullGolden = false;
+        if (fullGoldenWaveChance > 0f)
+            spawnFullGolden = Random.value < Mathf.Clamp01(fullGoldenWaveChance);
+
+        float combinedGoldenChance = Mathf.Clamp01(goldenChance + goldenChanceAddFromSpeed);
+
         for (int i = 0; i < boidsPerWave; i++)
         {
             Vector2 pos = (Vector2)sp.position + Random.insideUnitCircle * scatterRadius;
@@ -428,8 +437,11 @@ public class BoidManager : MonoBehaviour
 
 
             // ① 若你已算好 goldenChanceAddFromSpeed（0~1）：
-            float p = Mathf.Clamp01(goldenChance + goldenChanceAddFromSpeed);
-            if (Random.value < p)
+            bool makeGolden = spawnFullGolden;
+            if (!makeGolden && combinedGoldenChance > 0f && Random.value < combinedGoldenChance)
+                makeGolden = true;
+
+            if (makeGolden)
                 b.ConfigureAsGolden(goldenSpeedMultiplier, goldenForceMultiplier, goldenScoreValue, goldenColor);
 
 

--- a/Scripts/Shop/Mods/1002/CritOverflowBonusPer15.cs
+++ b/Scripts/Shop/Mods/1002/CritOverflowBonusPer15.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1002/Crit Overflow Bonus")]
+public class CritOverflowBonusPer15 : PlayerModifier
+{
+    public float overflowStep = 0.15f;
+    public float multiplierPerStep = 1f;
+
+    static int sStacks = 0;
+    static float sOverflowStep = 0.15f;
+    static float sBonusPerStack = 1f;
+
+    public override void Apply(PlayerController player)
+    {
+        sStacks++;
+        sOverflowStep = Mathf.Max(0.0001f, overflowStep);
+        sBonusPerStack = multiplierPerStep;
+        RefreshBonus();
+    }
+
+    static void RefreshBonus()
+    {
+        if (sStacks > 0 && sOverflowStep > 0f && sBonusPerStack != 0f)
+            GameManager.CritSetOverflowBonus(sOverflowStep, sBonusPerStack * sStacks);
+        else
+            GameManager.CritSetOverflowBonus(0f, 0f);
+    }
+
+    public static void HardReset()
+    {
+        sStacks = 0;
+        sOverflowStep = 0.15f;
+        sBonusPerStack = 1f;
+        GameManager.CritSetOverflowBonus(0f, 0f);
+    }
+}

--- a/Scripts/Shop/Mods/1002/FishSpeedUpAccelDown.cs
+++ b/Scripts/Shop/Mods/1002/FishSpeedUpAccelDown.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1002/Fish Speed×1.2 & Force×0.8")]
+public class FishSpeedUpAccelDown : PlayerModifier
+{
+    public float speedMultiplier = 1.2f;
+    public float forceMultiplier = 0.8f;
+
+    public override void Apply(PlayerController player)
+    {
+        var bm = BoidManager.Instance;
+        if (!bm)
+            bm = Object.FindFirstObjectByType<BoidManager>();
+        if (!bm) return;
+
+        bm.globalSpeedMult *= speedMultiplier;
+        bm.globalForceMult *= forceMultiplier;
+
+        if (bm.ActiveBoids != null)
+        {
+            foreach (var b in bm.ActiveBoids)
+            {
+                if (!b) continue;
+                b.MultiplyGlobalScales(speedMultiplier, forceMultiplier);
+            }
+        }
+    }
+}

--- a/Scripts/Shop/Mods/1002/GoldenWaveChance5.cs
+++ b/Scripts/Shop/Mods/1002/GoldenWaveChance5.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1002/5% Full Golden Wave")]
+public class GoldenWaveChance5 : PlayerModifier
+{
+    public float additionalChance = 0.05f;
+
+    public override void Apply(PlayerController player)
+    {
+        var bm = BoidManager.Instance;
+        if (!bm)
+            bm = Object.FindFirstObjectByType<BoidManager>();
+        if (!bm) return;
+
+        bm.fullGoldenWaveChance = Mathf.Clamp01(bm.fullGoldenWaveChance + additionalChance);
+    }
+}


### PR DESCRIPTION
## Summary
- add three new shop modifiers under Mods/1002 for fish speed/force, crit overflow bonuses, and full golden waves
- expand crit chance handling to allow values above 100% and grant overflow-based multiplier bonuses
- extend boid spawning logic to support full golden wave chances and reset data between runs

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de06c148cc83259b211a2c9e873500