### PR TITLE
Add spike-hit shop modifiers and integrate buffs

### DIFF
--- a/Scripts/BoidManager.cs
+++ b/Scripts/BoidManager.cs
@@ -438,7 +438,7 @@ public class BoidManager : MonoBehaviour
         if (fullGoldenWaveChance > 0f)
             spawnFullGolden = Random.value < Mathf.Clamp01(fullGoldenWaveChance);
 
-        float combinedGoldenChance = Mathf.Clamp01(goldenChance + goldenChanceAddFromSpeed);
+        float combinedGoldenChance = Mathf.Clamp01(goldenChance + goldenChanceAddFromSpeed + SpikeHitGoldenChanceBuff.CurrentBonus);
 
         for (int i = 0; i < boidsPerWave; i++)
         {

--- a/Scripts/GameManager.cs
+++ b/Scripts/GameManager.cs
@@ -96,7 +96,7 @@ public class GameManager : MonoBehaviour
 
     // ★ 修改总暴击率
     public float CritChance =>
-        Mathf.Max(0f, critFixedChance + critDynamicChance + critBonusFromSpikes + critBonusFromProgress);
+        Mathf.Max(0f, critFixedChance + critDynamicChance + critBonusFromSpikes + critBonusFromProgress + SpikeHitCritChanceBuff.CurrentBonus);
 
     static float critOverflowStep = 0f;
     static float critOverflowBonusPerStep = 0f;
@@ -319,7 +319,10 @@ public class GameManager : MonoBehaviour
         SpikeWallsPlusOneSpeed.HardReset();
         CritPerSpikeWall.HardReset();
         CritPlus5PerRound.HardReset();
-
+        SpikeHitNoPenaltyChance.HardReset();
+        SpikeHitAccelSpeedBuff.HardReset();
+        SpikeHitCritChanceBuff.HardReset();
+        SpikeHitGoldenChanceBuff.HardReset();
 
         if (bm) { bm.globalSpeedMult = 1f; bm.globalForceMult = 1f; }
     }
@@ -460,6 +463,10 @@ public class GameManager : MonoBehaviour
             SpikeWallsPlusOneSpeed.HardReset();
             CritPerSpikeWall.HardReset();
             CritPlus5PerRound.HardReset();
+            SpikeHitNoPenaltyChance.HardReset();
+            SpikeHitAccelSpeedBuff.HardReset();
+            SpikeHitCritChanceBuff.HardReset();
+            SpikeHitGoldenChanceBuff.HardReset();
 
 
             // 另外把 BoidManager 的全局乘子复原：
@@ -622,7 +629,7 @@ public class GameManager : MonoBehaviour
         var bm = FindFirstObjectByType<BoidManager>();
 
         // 金鱼概率（保持你原有写法，避免缺字段编译失败）
-        float goldChance = bm ? Mathf.Clamp01(bm.goldenChance + bm.goldenChanceAddFromSpeed) : 0f;
+        float goldChance = bm ? Mathf.Clamp01(bm.goldenChance + bm.goldenChanceAddFromSpeed + SpikeHitGoldenChanceBuff.CurrentBonus) : 0f;
 
         // 新：每波鱼群的鱼只数量（含额外金鱼，受所有道具与加成影响）
         int fishPerWave = bm ? bm.boidsPerWave + bm.extraGoldenPerWave : 0;

--- a/Scripts/PlayerController.cs
+++ b/Scripts/PlayerController.cs
@@ -27,11 +27,24 @@ public class PlayerController : MonoBehaviour
 
 
     // 提供给 ESC 面板显示
-    public float CurrentMaxSpeed => maxSpeed * (isSprintingEffective ? sprintSpeedMult : 1f);
-    public float CurrentAccelRate =>
-    accelRate * (isSprintingEffective
-        ? (ShiftNoAccelPenalty.Enabled ? 1f : sprintAccelMult)   // 装备道具时冲刺不降加速度
-        : 1f);
+    public float CurrentMaxSpeed
+    {
+        get
+        {
+            float sprintMult = isSprintingEffective ? sprintSpeedMult : 1f;
+            return maxSpeed * sprintMult * SpikeHitAccelSpeedBuff.CurrentSpeedMultiplier;
+        }
+    }
+    public float CurrentAccelRate
+    {
+        get
+        {
+            float sprintMult = isSprintingEffective
+                ? (ShiftNoAccelPenalty.Enabled ? 1f : sprintAccelMult)   // 装备道具时冲刺不降加速度
+                : 1f;
+            return accelRate * sprintMult * SpikeHitAccelSpeedBuff.CurrentAccelMultiplier;
+        }
+    }
 
 
     // ---------- runtime ----------

--- a/Scripts/Shop/Mods/1003/SpikeHitAccelSpeedBuff.cs
+++ b/Scripts/Shop/Mods/1003/SpikeHitAccelSpeedBuff.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1003/Spike Hit Accel & Speed Buff")]
+public class SpikeHitAccelSpeedBuff : PlayerModifier
+{
+    public float duration = 5f;
+    public float accelMultiplier = 1.5f;
+    public float speedMultiplier = 1.25f;
+
+    static bool sEnabled = false;
+    static float sDuration = 5f;
+    static float sAccelMultiplier = 1.5f;
+    static float sSpeedMultiplier = 1.25f;
+    static float sBuffEndTime = 0f;
+
+    public override void Apply(PlayerController player)
+    {
+        sEnabled = true;
+        sDuration = Mathf.Max(0f, duration);
+        sAccelMultiplier = Mathf.Max(0f, accelMultiplier);
+        sSpeedMultiplier = Mathf.Max(0f, speedMultiplier);
+    }
+
+    public static void RegisterSpikeHit()
+    {
+        if (!sEnabled)
+            return;
+        float end = Time.time + sDuration;
+        if (end > sBuffEndTime)
+            sBuffEndTime = end;
+    }
+
+    public static float CurrentAccelMultiplier
+    {
+        get
+        {
+            if (!sEnabled)
+                return 1f;
+            if (Time.time >= sBuffEndTime)
+                return 1f;
+            return sAccelMultiplier;
+        }
+    }
+
+    public static float CurrentSpeedMultiplier
+    {
+        get
+        {
+            if (!sEnabled)
+                return 1f;
+            if (Time.time >= sBuffEndTime)
+                return 1f;
+            return sSpeedMultiplier;
+        }
+    }
+
+    public static void HardReset()
+    {
+        sEnabled = false;
+        sDuration = 5f;
+        sAccelMultiplier = 1.5f;
+        sSpeedMultiplier = 1.25f;
+        sBuffEndTime = 0f;
+    }
+}

--- a/Scripts/Shop/Mods/1003/SpikeHitCritChanceBuff.cs
+++ b/Scripts/Shop/Mods/1003/SpikeHitCritChanceBuff.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1003/Spike Hit Crit Chance Buff")]
+public class SpikeHitCritChanceBuff : PlayerModifier
+{
+    public float duration = 5f;
+    [Range(0f, 1f)] public float critBonus = 0.3f;
+
+    static bool sEnabled = false;
+    static float sDuration = 5f;
+    static float sCritBonus = 0.3f;
+    static float sBuffEndTime = 0f;
+
+    public override void Apply(PlayerController player)
+    {
+        sEnabled = true;
+        sDuration = Mathf.Max(0f, duration);
+        sCritBonus = Mathf.Max(0f, critBonus);
+    }
+
+    public static void RegisterSpikeHit()
+    {
+        if (!sEnabled)
+            return;
+        float end = Time.time + sDuration;
+        if (end > sBuffEndTime)
+            sBuffEndTime = end;
+    }
+
+    public static float CurrentBonus
+    {
+        get
+        {
+            if (!sEnabled)
+                return 0f;
+            if (Time.time >= sBuffEndTime)
+                return 0f;
+            return sCritBonus;
+        }
+    }
+
+    public static void HardReset()
+    {
+        sEnabled = false;
+        sDuration = 5f;
+        sCritBonus = 0.3f;
+        sBuffEndTime = 0f;
+    }
+}

--- a/Scripts/Shop/Mods/1003/SpikeHitGoldenChanceBuff.cs
+++ b/Scripts/Shop/Mods/1003/SpikeHitGoldenChanceBuff.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1003/Spike Hit Golden Chance Buff")]
+public class SpikeHitGoldenChanceBuff : PlayerModifier
+{
+    public float duration = 5f;
+    [Range(0f, 1f)] public float goldenChanceBonus = 0.15f;
+
+    static bool sEnabled = false;
+    static float sDuration = 5f;
+    static float sGoldenBonus = 0.15f;
+    static float sBuffEndTime = 0f;
+
+    public override void Apply(PlayerController player)
+    {
+        sEnabled = true;
+        sDuration = Mathf.Max(0f, duration);
+        sGoldenBonus = Mathf.Max(0f, goldenChanceBonus);
+    }
+
+    public static void RegisterSpikeHit()
+    {
+        if (!sEnabled)
+            return;
+        float end = Time.time + sDuration;
+        if (end > sBuffEndTime)
+            sBuffEndTime = end;
+    }
+
+    public static float CurrentBonus
+    {
+        get
+        {
+            if (!sEnabled)
+                return 0f;
+            if (Time.time >= sBuffEndTime)
+                return 0f;
+            return sGoldenBonus;
+        }
+    }
+
+    public static void HardReset()
+    {
+        sEnabled = false;
+        sDuration = 5f;
+        sGoldenBonus = 0.15f;
+        sBuffEndTime = 0f;
+    }
+}

--- a/Scripts/Shop/Mods/1003/SpikeHitNoPenaltyChance.cs
+++ b/Scripts/Shop/Mods/1003/SpikeHitNoPenaltyChance.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "CatchFish/Modifier/1003/Spike Hit No Penalty 50%")]
+public class SpikeHitNoPenaltyChance : PlayerModifier
+{
+    [Range(0f, 1f)] public float noPenaltyChance = 0.5f;
+
+    static bool sEnabled = false;
+    static float sChance = 0.5f;
+
+    public override void Apply(PlayerController player)
+    {
+        sEnabled = true;
+        sChance = Mathf.Clamp01(noPenaltyChance);
+    }
+
+    public static bool TryPreventPenalty()
+    {
+        if (!sEnabled)
+            return false;
+        return Random.value < sChance;
+    }
+
+    public static void HardReset()
+    {
+        sEnabled = false;
+        sChance = 0.5f;
+    }
+}

--- a/Scripts/World/Spike.cs
+++ b/Scripts/World/Spike.cs
@@ -16,10 +16,18 @@ public class Spike : MonoBehaviour
             var gm = GameManager.Instance;
             if (gm != null)
             {
-                int cur  = gm.CurrentMoney;
-                int loss = Mathf.Max(1, Mathf.FloorToInt(cur * GameManager.Instance.spikePenaltyRate));
-                gm.LoseMoney(loss);
+                bool skipPenalty = SpikeHitNoPenaltyChance.TryPreventPenalty();
+                if (!skipPenalty)
+                {
+                    int cur  = gm.CurrentMoney;
+                    int loss = Mathf.Max(1, Mathf.FloorToInt(cur * GameManager.Instance.spikePenaltyRate));
+                    gm.LoseMoney(loss);
+                }
             }
+
+            SpikeHitAccelSpeedBuff.RegisterSpikeHit();
+            SpikeHitCritChanceBuff.RegisterSpikeHit();
+            SpikeHitGoldenChanceBuff.RegisterSpikeHit();
             return;
         }
 


### PR DESCRIPTION
## Summary
- add four new shop modifiers under 1003 for spike-hit effects: penalty avoidance, movement buff, crit buff, and golden chance buff
- hook spike collisions to respect the new modifiers and refresh temporary buffs
- surface the temporary bonuses in player movement, crit calculations, golden chance display, and spawn logic, plus reset them with other run data

## Testing
- Not run (Unity project without automated tests in container)


------
https://chatgpt.com/codex/tasks/task_e_68df2cba990c83259664548542de346d